### PR TITLE
Change battery-historian's link

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -6,7 +6,7 @@ title: references
 A collection of useful links to understand and reduce battery consumption
 
 ## Tools
-- [Battery Historian](https://developer.qualcomm.com/software/trepn-power-profiler): A really useful tool to visualize and explore Android bug reports.
+- [Battery Historian](https://github.com/google/battery-historian): A really useful tool to visualize and explore Android bug reports.
 - [Trepn](https://developer.qualcomm.com/software/trepn-power-profiler): An on device battery profiler with it's own power model.
 - [AT&T Network Optimizer](https://developer.att.com/video-optimizer/docs): Great for modelling and observing network locally.
 


### PR DESCRIPTION
Summary:
Closes #15

 Link to battery-historian was earlier pointing to Trepn power profiler page. Changed it to point to battery-historian github page.
Closes https://github.com/facebookincubator/Battery-Metrics/pull/16

Differential Revision: D6416261

Pulled By: kunalb

fbshipit-source-id: 960903884ea33f3b10945b9c17ad5236b3edad07