### PR TITLE
Add EnhancedNetworkMetricsCollector for fg/bg distinction

### DIFF
--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:2.8.0'
     testImplementation 'org.mockito:mockito-core:1.9.5'
     testImplementation 'org.robolectric:robolectric:3.4.2'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.1'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/EnhancedNetworkMetrics.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/EnhancedNetworkMetrics.java
@@ -1,0 +1,82 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.battery.metrics.network;
+
+import android.support.annotation.Nullable;
+import com.facebook.battery.metrics.core.SystemMetrics;
+
+/** Alternative to {@link NetworkMetrics} which offers fg/bg app state distinction. */
+public class EnhancedNetworkMetrics extends SystemMetrics<EnhancedNetworkMetrics> {
+
+  /**
+   * True if fg/bg distinction was possible; false otherwise and all data will have been assumed to
+   * have happened in the foreground.
+   */
+  public boolean supportsBgDetection;
+
+  public final NetworkMetrics fgMetrics = new NetworkMetrics();
+  public final NetworkMetrics bgMetrics = new NetworkMetrics();
+
+  public EnhancedNetworkMetrics() {}
+
+  @Override
+  public EnhancedNetworkMetrics sum(
+      @Nullable EnhancedNetworkMetrics b, @Nullable EnhancedNetworkMetrics output) {
+    if (output == null) {
+      output = new EnhancedNetworkMetrics();
+    }
+    if (b == null) {
+      output.set(this);
+    } else {
+      fgMetrics.sum(b.fgMetrics, output.fgMetrics);
+      bgMetrics.sum(b.bgMetrics, output.bgMetrics);
+    }
+
+    return output;
+  }
+
+  @Override
+  public EnhancedNetworkMetrics diff(
+      @Nullable EnhancedNetworkMetrics b, @Nullable EnhancedNetworkMetrics output) {
+    if (output == null) {
+      output = new EnhancedNetworkMetrics();
+    }
+    if (b == null) {
+      output.set(this);
+    } else {
+      fgMetrics.diff(b.fgMetrics, output.fgMetrics);
+      bgMetrics.diff(b.bgMetrics, output.bgMetrics);
+    }
+
+    return output;
+  }
+
+  @Override
+  public EnhancedNetworkMetrics set(EnhancedNetworkMetrics b) {
+    fgMetrics.set(b.fgMetrics);
+    bgMetrics.set(b.bgMetrics);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    EnhancedNetworkMetrics that = (EnhancedNetworkMetrics) o;
+
+    if (supportsBgDetection != that.supportsBgDetection) return false;
+    if (!fgMetrics.equals(that.fgMetrics)) return false;
+    if (!bgMetrics.equals(that.bgMetrics)) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (supportsBgDetection ? 1 : 0);
+    result = 31 * result + fgMetrics.hashCode();
+    result = 31 * result + bgMetrics.hashCode();
+    return result;
+  }
+}

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/EnhancedNetworkMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/EnhancedNetworkMetricsCollector.java
@@ -1,0 +1,49 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.battery.metrics.network;
+
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.BG;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.FG;
+
+import android.content.Context;
+import com.facebook.battery.metrics.core.SystemMetricsCollector;
+import com.facebook.infer.annotation.ThreadSafe;
+
+/**
+ * Alternative to {@link NetworkMetricsCollector} which supports distinguishing
+ * foreground/background app states where possible (in particular when using qtaguid stats).
+ */
+public class EnhancedNetworkMetricsCollector
+    extends SystemMetricsCollector<EnhancedNetworkMetrics> {
+
+  private final NetworkBytesCollector mCollector;
+  private final long[] mBytes;
+
+  public EnhancedNetworkMetricsCollector(Context context) {
+    mCollector = NetworkBytesCollector.create(context);
+    mBytes = NetworkBytesCollector.createByteArray();
+  }
+
+  @Override
+  @ThreadSafe(enableChecks = false)
+  public synchronized boolean getSnapshot(EnhancedNetworkMetrics snapshot) {
+    if (!mCollector.getTotalBytes(mBytes)) {
+      return false;
+    }
+
+    boolean supportsBgDetection = mCollector.supportsBgDistinction();
+    snapshot.supportsBgDetection = supportsBgDetection;
+    NetworkMetricsCollector.resetMetrics(snapshot.fgMetrics);
+    NetworkMetricsCollector.addMetricsFromBytes(snapshot.fgMetrics, mBytes, FG);
+    if (supportsBgDetection) {
+      NetworkMetricsCollector.resetMetrics(snapshot.bgMetrics);
+      NetworkMetricsCollector.addMetricsFromBytes(snapshot.bgMetrics, mBytes, BG);
+    }
+    return true;
+  }
+
+  @Override
+  public EnhancedNetworkMetrics createMetrics() {
+    return new EnhancedNetworkMetrics();
+  }
+}

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkBytesCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkBytesCollector.java
@@ -10,15 +10,29 @@ package com.facebook.battery.metrics.network;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.Size;
 
 abstract public class NetworkBytesCollector {
 
-  abstract boolean getTotalBytes(long[] bytes);
+  public static final int RX = 0b000;
+  public static final int TX = 0b001;
+  public static final int MOBILE = 0b010;
+  public static final int WIFI = 0b000;
+  public static final int FG = 0b000;
+  public static final int BG = 0b100;
+
+  public static @Size(8) long[] createByteArray() {
+    return new long[8];
+  }
+
+  public abstract boolean supportsBgDistinction();
+
+  public abstract boolean getTotalBytes(@Size(8) long[] bytes);
 
   @SuppressLint("ObsoleteSdkInt")
   public static NetworkBytesCollector create(Context context) {
     if (Build.VERSION.SDK_INT >= 14) {
-      long[] bytes = new long[4];
+      long[] bytes = new long[8];
       QTagUidNetworkBytesCollector collector = new QTagUidNetworkBytesCollector();
 
       // Sanity check that the collector can work before falling back to the UidStats based

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkMetrics.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkMetrics.java
@@ -13,6 +13,8 @@ import com.facebook.battery.metrics.core.SystemMetrics;
 /**
  * Information about network metrics: bytes sent/received on mobile radio and WiFi, as well as radio
  * uptime.
+ *
+ * <p>For foreground/background app state distinction, use {@link EnhancedNetworkMetrics}
  */
 public class NetworkMetrics extends SystemMetrics<NetworkMetrics> {
 

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/QTagUidNetworkBytesCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/QTagUidNetworkBytesCollector.java
@@ -7,11 +7,6 @@
  */
 package com.facebook.battery.metrics.network;
 
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.MOBILE;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.RX;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.TX;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.WIFI;
-
 import android.annotation.SuppressLint;
 import android.support.annotation.VisibleForTesting;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
@@ -64,6 +59,11 @@ class QTagUidNetworkBytesCollector extends NetworkBytesCollector {
   }
 
   @Override
+  public boolean supportsBgDistinction() {
+    return true;
+  }
+
+  @Override
   public boolean getTotalBytes(long[] bytes) {
     if (!mIsValid) {
       return false;
@@ -96,8 +96,11 @@ class QTagUidNetworkBytesCollector extends NetworkBytesCollector {
           continue;
         }
 
-        skipPast(' '); // cnt_set
-        int field = isWifi ? WIFI : MOBILE;
+        long cntSet = readNumber();
+
+        int field = 0;
+        field |= (isWifi ? WIFI : MOBILE);
+        field |= (cntSet == 0 ? BG : FG);
         bytes[field | RX] += readNumber();
         skipPast(' '); // rx_packets
         bytes[field | TX] += readNumber();

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollector.java
@@ -8,10 +8,6 @@
 package com.facebook.battery.metrics.network;
 
 import static android.net.ConnectivityManager.TYPE_WIFI;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.MOBILE;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.RX;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.TX;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.WIFI;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -70,6 +66,11 @@ class TrafficStatsNetworkBytesCollector extends NetworkBytesCollector {
         new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
 
     updateTotalBytes();
+  }
+
+  @Override
+  public boolean supportsBgDistinction() {
+    return false;
   }
 
   @Override

--- a/metrics/src/test/java/com/facebook/battery/metrics/network/EnhancedNetworkMetricsTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/network/EnhancedNetworkMetricsTest.java
@@ -1,0 +1,16 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.battery.metrics.network;
+
+import com.facebook.battery.metrics.core.SystemMetricsTest;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class EnhancedNetworkMetricsTest extends SystemMetricsTest<EnhancedNetworkMetrics> {
+
+  @Override
+  protected Class<EnhancedNetworkMetrics> getClazz() {
+    return EnhancedNetworkMetrics.class;
+  }
+}

--- a/metrics/src/test/java/com/facebook/battery/metrics/network/NetworkMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/network/NetworkMetricsCollectorTest.java
@@ -1,0 +1,108 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.battery.metrics.network;
+
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.BG;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.FG;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.MOBILE;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.RX;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.TX;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.WIFI;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import java.util.ArrayDeque;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({NetworkBytesCollector.class})
+public class NetworkMetricsCollectorTest {
+  private NetworkMetricsCollector mMetricsCollector;
+  private TestNetworkBytesCollector mBytesCollector;
+
+  @Before
+  public void setUp() {
+    PowerMockito.mockStatic(NetworkBytesCollector.class);
+
+    mBytesCollector = new TestNetworkBytesCollector();
+    PowerMockito.when(NetworkBytesCollector.create(null)).thenReturn(mBytesCollector);
+    PowerMockito.when(NetworkBytesCollector.createByteArray()).thenCallRealMethod();
+    mMetricsCollector = new NetworkMetricsCollector(null);
+  }
+
+  @Test
+  public void testWithoutBgDetection() {
+    long[] bytes = new long[4];
+    bytes[MOBILE | TX | FG] = 1;
+    bytes[WIFI | RX | FG] = 2;
+    mBytesCollector.yieldTotalBytes(bytes);
+
+    NetworkMetrics metrics = mMetricsCollector.createMetrics();
+    boolean hasMetrics = mMetricsCollector.getSnapshot(metrics);
+    assertThat(hasMetrics).isTrue();
+
+    NetworkMetrics expected = new NetworkMetrics();
+    expected.mobileBytesTx = 1;
+    expected.wifiBytesRx = 2;
+    assertThat(metrics).isEqualTo(expected);
+  }
+
+  @Test
+  public void testWithBgDetection() {
+    long[] bytes = new long[8];
+    bytes[MOBILE | TX | FG] = 1;
+    bytes[WIFI | RX | FG] = 2;
+    bytes[MOBILE | TX | BG] = 30;
+    bytes[WIFI | RX | BG] = 40;
+    mBytesCollector.yieldTotalBytes(bytes);
+
+    NetworkMetrics metrics = mMetricsCollector.createMetrics();
+    boolean hasMetrics = mMetricsCollector.getSnapshot(metrics);
+    assertThat(hasMetrics).isTrue();
+
+    NetworkMetrics expected = new NetworkMetrics();
+    expected.mobileBytesTx = 31;
+    expected.wifiBytesRx = 42;
+    assertThat(metrics).isEqualTo(expected);
+  }
+
+  private static class TestNetworkBytesCollector extends NetworkBytesCollector {
+    private final ArrayDeque<long[]> mNextBytes = new ArrayDeque<>();
+    private boolean mSupportsBgDistinction;
+
+    public void yieldTotalBytes(long[] bytes) {
+      mSupportsBgDistinction = determineSupportsBgDistinction(bytes.length);
+      mNextBytes.addLast(bytes);
+    }
+
+    private static boolean determineSupportsBgDistinction(int byteLength) {
+      switch (byteLength) {
+        case 8:
+          return true;
+        case 4:
+          return false;
+        default:
+          throw new IllegalArgumentException("length=" + byteLength);
+      }
+    }
+
+    @Override
+    public boolean supportsBgDistinction() {
+      return mSupportsBgDistinction;
+    }
+
+    @Override
+    public boolean getTotalBytes(long[] bytes) {
+      if (!mNextBytes.isEmpty()) {
+        long[] next = mNextBytes.removeFirst();
+        System.arraycopy(next, 0, bytes, 0, next.length);
+        return true;
+      }
+      return false;
+    }
+  }
+}

--- a/metrics/src/test/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollectorTest.java
@@ -8,10 +8,10 @@
 package com.facebook.battery.metrics.network;
 
 import static android.net.TrafficStats.UNSUPPORTED;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.MOBILE;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.RX;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.TX;
-import static com.facebook.battery.metrics.network.NetworkMetricsCollector.WIFI;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.MOBILE;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.RX;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.TX;
+import static com.facebook.battery.metrics.network.NetworkBytesCollector.WIFI;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import android.content.Context;


### PR DESCRIPTION
Summary:
Add EnhancedNetworkMetricsCollector alongside the existing NetworkMetricsCollector
which offers the ability to distinguish data usage based on fg/bg app state where qtaguid
stats are available.  This API is made public to external customers in such a way that it does not break old functionality.

Reviewed By: kunalb

Differential Revision: D6279299

fbshipit-source-id: 470d947012c5a2e98fad39d5601668300e2b475b