### PR TITLE
Fix failing tests in DeviceBatteryMetricsCollectorTest & AppWakeupMet…

### DIFF
--- a/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
@@ -15,6 +15,7 @@ import android.support.annotation.Nullable;
 import com.facebook.battery.metrics.core.ShadowSystemClock;
 import com.facebook.battery.metrics.core.SystemMetricsCollectorTest;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,11 @@ public class WakeLockMetricsCollectorTest
             throw new RuntimeException(tag + " " + message, cause);
           }
         });
+  }
+
+  @After
+  public void tearDown() {
+    SystemMetricsLogger.setDelegate(null);
   }
 
   @Test


### PR DESCRIPTION
Summary:
Closes #11

 SystemMetricsLogger's delegate was being set to an anonymous class which was throwing a runtime exception, in the `WakeLockMetricsCollectorTest` class's setup method. Hence in the test suite, all the calls made to SystemMetricsLogger's wtf method were being rerouted to this delegate. This was leading to three tests failing in the `DeviceBatteryMetricsCollectorTest` & `AppWakeupMetricsCollectorTest` classes because of the aforementioned runtime exception. In order to fix this, I deleted the lines of code which were setting the delegate in the setup method of `WakeLockMetricsCollectorTest`.
Closes https://github.com/facebookincubator/Battery-Metrics/pull/17

Differential Revision: D6469148

Pulled By: kunalb

fbshipit-source-id: 490e59c10a6c098a40f2683805a6d1adac5e6ba0