### PR TITLE
Fix synchronization issue in CpuFrequencyMetricsCollector

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollector.java
@@ -70,7 +70,7 @@ public class CpuFrequencyMetricsCollector extends SystemMetricsCollector<CpuFreq
     return mFiles[core];
   }
 
-  private static synchronized boolean readCoreStats(SparseIntArray array, ProcFileReader reader) {
+  private synchronized boolean readCoreStats(SparseIntArray array, ProcFileReader reader) {
     array.clear();
 
     // A failure is mostly expected because files become inaccessible in case of


### PR DESCRIPTION
Summary:
The bug is that I expected all access over the readers to be synchronized: what's happening is that in #getReader is synchronized on `this`; it dutifully adjusts the code and creates / resets the instance without doubling the work; unfortunately #readCoreStats is static and synchronized on the class instance instead, so #readCoreStats could still be running while another `getSnapshot` is triggered calling through to `getReader` which resets the reader in between iterations.

I think this is the most likely cause of the ArrayIndexOutOfBoundsException crash in T23390654:
- all the exceptions are coming from CpuFrequencyMetricsCollector and not CpuMetricsCollector, both of which use ProcFileReader -- which makes me trust that class.
- this exception is much higher in messenger compared to fb4a presumably because scout is checking this much more frequently than in fb4a, greatly increasing the chances of a crash.
- the state at which it fails seems to be impossible: mPosition is set to -1 after being incremented -- I've been working through all possible states and haven't yet found any place where mPosition would reach -2.

Reviewed By: innoavator

Differential Revision: D6539307

fbshipit-source-id: ede01b08d848213e88efb8822248d66ba038e153