### PR TITLE
Add ability to set custom previous snapshot in StatefulSystemMetricsC…

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollector.java
@@ -43,19 +43,21 @@ public class StatefulSystemMetricsCollector<
   public StatefulSystemMetricsCollector(S collector) {
     this(
         collector, collector.createMetrics(), collector.createMetrics(), collector.createMetrics());
+    mIsValid &= collector.getSnapshot(mPrev);
   }
 
   /**
    * Wraps the underlying collector, but with custom metrics objects: useful for passing in custom
    * metrics objects, such as {@link com.facebook.battery.metrics.wakelock.WakeLockMetrics}.
+   *
+   * <p>Note that this doesn't auto-initialize the previous diff and mainly exists to make it
+   * convenient to set a custom initial snapshot.
    */
   public StatefulSystemMetricsCollector(S collector, R curr, R prev, R diff) {
     mCollector = collector;
     mCurr = curr;
     mPrev = prev;
     mDiff = diff;
-
-    mIsValid &= mCollector.getSnapshot(this.mPrev);
   }
 
   /** Access the underlying collector. */

--- a/metrics/src/test/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollectorTest.java
@@ -18,7 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 public class StatefulSystemMetricsCollectorTest {
 
   @Test
-  public void testGetLatestDiff() {
+  public void testGetLatestDiffAndReset() throws Exception {
     DummyMetricCollector collector = new DummyMetricCollector();
     collector.currentValue = 10;
 
@@ -29,6 +29,40 @@ public class StatefulSystemMetricsCollectorTest {
     collector.currentValue = 20;
     assertThat(statefulCollector.getLatestDiffAndReset().value).isEqualTo(10);
     assertThat(statefulCollector.getLatestDiffAndReset().value).isEqualTo(0);
+  }
+
+  @Test
+  public void testCustomBaseSnapshot() throws Exception {
+    DummyMetric metric = new DummyMetric();
+    metric.value = 0;
+
+    DummyMetricCollector collector = new DummyMetricCollector();
+    collector.currentValue = 10;
+
+    StatefulSystemMetricsCollector<DummyMetric, DummyMetricCollector> withCustomInitialSnapshot =
+        new StatefulSystemMetricsCollector<>(
+            collector, collector.createMetrics(), metric, collector.createMetrics());
+    StatefulSystemMetricsCollector<DummyMetric, DummyMetricCollector> defaultInitialSnapshot =
+        new StatefulSystemMetricsCollector<>(collector);
+
+    assertThat(withCustomInitialSnapshot.getLatestDiff().value).isEqualTo(10);
+    assertThat(defaultInitialSnapshot.getLatestDiff().value).isEqualTo(0);
+  }
+
+  @Test
+  public void testGetLatestDiff() {
+    DummyMetricCollector collector = new DummyMetricCollector();
+    collector.currentValue = 10;
+
+    StatefulSystemMetricsCollector<DummyMetric, DummyMetricCollector> statefulCollector =
+        new StatefulSystemMetricsCollector<>(collector);
+    assertThat(statefulCollector.getLatestDiff().value).isEqualTo(0);
+
+    collector.currentValue = 20;
+    assertThat(statefulCollector.getLatestDiff().value).isEqualTo(10);
+
+    collector.currentValue = 30;
+    assertThat(statefulCollector.getLatestDiff().value).isEqualTo(20);
   }
 }
 


### PR DESCRIPTION
…ollector

Summary:
This changes the API of StatefulSystemMetricsCollector slightly: the 3 argument explicit version no longer auto-initializes. I'll make sure to explicitly note this in the next version bump of the library to warn people realizing on this.

BluetoothMetrics was the only existing call site to use this, adjusted that in the code in this diff.

Differential Revision: D6583868

fbshipit-source-id: 377b62bef75fb94c8f8b31c957cfbc6284e7ac36