### PR TITLE
Delete old cpu frequency metrics

### DIFF
--- a/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsTest.java
@@ -148,4 +148,32 @@ public class CpuFrequencyMetricsTest {
 
     assertThat(metricsA).isEqualTo(output);
   }
+
+  @Test
+  public void testSingleCoreToJSONObject() {
+    CpuFrequencyMetrics metrics = new CpuFrequencyMetrics();
+    metrics.timeInStateS[0].put(100, 100);
+    assertThat(metrics.toJSONObject().toString()).isEqualTo("{\"1\":{\"100\":100}}");
+  }
+
+  @Test
+  public void testMultipleCoresToJSONObject() {
+    CpuFrequencyMetrics metrics = new CpuFrequencyMetrics();
+    metrics.timeInStateS[0].put(100, 100);
+    metrics.timeInStateS[2].put(200, 200);
+    assertThat(metrics.toJSONObject().toString())
+        .isEqualTo("{\"1\":{\"100\":100},\"4\":{\"200\":200}}");
+  }
+
+  @Test
+  public void testCoreCombinationToJSONObject() {
+    CpuFrequencyMetrics metrics = new CpuFrequencyMetrics();
+    metrics.timeInStateS[0].put(100, 100);
+    metrics.timeInStateS[2].put(100, 100);
+    metrics.timeInStateS[1].put(200, 200);
+    metrics.timeInStateS[3].put(200, 200);
+
+    assertThat(metrics.toJSONObject().toString())
+        .isEqualTo("{\"a\":{\"200\":200},\"5\":{\"100\":100}}");
+  }
 }

--- a/reporters/src/test/java/com/facebook/battery/reporter/cpu/CpuFrequencyMetricsReporterTest.java
+++ b/reporters/src/test/java/com/facebook/battery/reporter/cpu/CpuFrequencyMetricsReporterTest.java
@@ -42,36 +42,4 @@ public class CpuFrequencyMetricsReporterTest {
     mReporter.reportTo(mMetrics, mEvent);
     assertThat(mEvent.eventMap.isEmpty()).isTrue();
   }
-
-  @Test
-  public void testSingleCore() {
-    mMetrics.timeInStateS[0].put(100, 100);
-    mReporter.reportTo(mMetrics, mEvent);
-    assertThat(mEvent.eventMap.isEmpty()).isFalse();
-    assertThat(mEvent.eventMap.get(CpuFrequencyMetricsReporter.CPU_TIME_IN_STATE_S))
-        .isEqualTo("{\"1\":{\"100\":100}}");
-  }
-
-  @Test
-  public void testMultipleCores() {
-    mMetrics.timeInStateS[0].put(100, 100);
-    mMetrics.timeInStateS[2].put(200, 200);
-    mReporter.reportTo(mMetrics, mEvent);
-    assertThat(mEvent.eventMap.isEmpty()).isFalse();
-    assertThat(mEvent.eventMap.get(CpuFrequencyMetricsReporter.CPU_TIME_IN_STATE_S))
-        .isEqualTo("{\"1\":{\"100\":100},\"4\":{\"200\":200}}");
-  }
-
-  @Test
-  public void testCoreCombination() {
-    mMetrics.timeInStateS[0].put(100, 100);
-    mMetrics.timeInStateS[2].put(100, 100);
-    mMetrics.timeInStateS[1].put(200, 200);
-    mMetrics.timeInStateS[3].put(200, 200);
-
-    mReporter.reportTo(mMetrics, mEvent);
-    assertThat(mEvent.eventMap.isEmpty()).isFalse();
-    assertThat(mEvent.eventMap.get(CpuFrequencyMetricsReporter.CPU_TIME_IN_STATE_S))
-        .isEqualTo("{\"a\":{\"200\":200},\"5\":{\"100\":100}}");
-  }
 }


### PR DESCRIPTION
Summary: Moving cpu time in state as well; this one logs a slightly different / compressed format than the previous version which is simpler to parse. I'll update the server side pipelines to handle this as well before landing this diff.

Differential Revision: D6586155

fbshipit-source-id: dbd9b038be3bc1c19d0718a866a26892395934d0