### PR TITLE
Improve handling incompatible composite metrics

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/composite/CompositeMetrics.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/composite/CompositeMetrics.java
@@ -35,8 +35,12 @@ public class CompositeMetrics extends SystemMetrics<CompositeMetrics> {
       for (int i = 0, size = mMetricsMap.size(); i < size; i++) {
         Class c = mMetricsMap.keyAt(i);
         boolean valid = isValid(c) && b.isValid(c);
+
         if (valid) {
-          getMetric(c).diff(b.getMetric(c), result.getMetric(c));
+          SystemMetrics resultMetric = result.getMetric(c);
+          if (resultMetric != null) {
+            getMetric(c).diff(b.getMetric(c), resultMetric);
+          }
         }
         result.setIsValid(c, valid);
       }
@@ -56,8 +60,12 @@ public class CompositeMetrics extends SystemMetrics<CompositeMetrics> {
       for (int i = 0, size = mMetricsMap.size(); i < size; i++) {
         Class c = mMetricsMap.keyAt(i);
         boolean valid = isValid(c) && b.isValid(c);
+
         if (valid) {
-          getMetric(c).sum(b.getMetric(c), result.getMetric(c));
+          SystemMetrics resultMetric = result.getMetric(c);
+          if (resultMetric != null) {
+            getMetric(c).sum(b.getMetric(c), resultMetric);
+          }
         }
         result.setIsValid(c, valid);
       }
@@ -66,11 +74,16 @@ public class CompositeMetrics extends SystemMetrics<CompositeMetrics> {
   }
 
   @Override
-  public CompositeMetrics set(CompositeMetrics result) {
+  public CompositeMetrics set(CompositeMetrics input) {
     for (int i = 0, size = mMetricsMap.size(); i < size; i++) {
       Class c = mMetricsMap.keyAt(i);
-      getMetric(c).set(result.getMetric(c));
-      setIsValid(c, result.isValid(c));
+      SystemMetrics metric = input.getMetric(c);
+      if (metric != null) {
+        getMetric(c).set(metric);
+        setIsValid(c, input.isValid(c));
+      } else {
+        setIsValid(c, false);
+      }
     }
     return this;
   }

--- a/metrics/src/test/java/com/facebook/battery/metrics/composite/CompositeMetricsTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/composite/CompositeMetricsTest.java
@@ -10,8 +10,10 @@ package com.facebook.battery.metrics.composite;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.facebook.battery.metrics.core.SystemMetricsTest;
+import com.facebook.battery.metrics.cpu.CpuMetrics;
 import com.facebook.battery.metrics.time.TimeMetrics;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -74,5 +76,44 @@ public class CompositeMetricsTest extends SystemMetricsTest<CompositeMetrics> {
     metrics.setIsValid(TimeMetrics.class, true);
 
     return metrics;
+  }
+
+  @Test
+  public void testInconsistentSet() throws Exception {
+    CompositeMetrics metricsA =
+        new CompositeMetrics().putMetric(TimeMetrics.class, new TimeMetrics());
+    CompositeMetrics metricsB =
+        new CompositeMetrics().putMetric(CpuMetrics.class, new CpuMetrics());
+    metricsA.set(metricsB);
+
+    assertThat(metricsA.isValid(TimeMetrics.class)).isFalse();
+  }
+
+  @Test
+  public void testInconsistentSum() throws Exception {
+    CompositeMetrics sum = new CompositeMetrics().putMetric(CpuMetrics.class, new CpuMetrics());
+    CompositeMetrics metricsA =
+        new CompositeMetrics().putMetric(TimeMetrics.class, new TimeMetrics());
+    CompositeMetrics metricsB =
+        new CompositeMetrics().putMetric(CpuMetrics.class, new CpuMetrics());
+
+    metricsA.sum(metricsB, sum);
+
+    assertThat(sum.isValid(TimeMetrics.class)).isFalse();
+    assertThat(sum.isValid(CpuMetrics.class)).isFalse();
+  }
+
+  @Test
+  public void testInconsistentDiff() throws Exception {
+    CompositeMetrics diff = new CompositeMetrics().putMetric(CpuMetrics.class, new CpuMetrics());
+    CompositeMetrics metricsA =
+        new CompositeMetrics().putMetric(TimeMetrics.class, new TimeMetrics());
+    CompositeMetrics metricsB =
+        new CompositeMetrics().putMetric(CpuMetrics.class, new CpuMetrics());
+
+    metricsA.diff(metricsB, diff);
+
+    assertThat(diff.isValid(TimeMetrics.class)).isFalse();
+    assertThat(diff.isValid(CpuMetrics.class)).isFalse();
   }
 }


### PR DESCRIPTION
Summary: I realized it was possible to cause NPEs by setting inconsistent composite metrics (with different internal sets of metrics); just strengthen the code against that.

Differential Revision: D6717780

fbshipit-source-id: e626ef4323e053e9693af5ff0cb13b1ca95ef2e2