### PR TITLE
Move wakelocks to new instrumentation

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/wakelock/WakeLockMetrics.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/wakelock/WakeLockMetrics.java
@@ -10,7 +10,10 @@ package com.facebook.battery.metrics.wakelock;
 import android.support.annotation.Nullable;
 import android.support.v4.util.SimpleArrayMap;
 import com.facebook.battery.metrics.core.SystemMetrics;
+import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.battery.metrics.core.Utilities;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Maintains state about total active wakelocks and the current time available.
@@ -157,5 +160,27 @@ public class WakeLockMetrics extends SystemMetrics<WakeLockMetrics> {
         + ", acquiredCount="
         + acquiredCount
         + '}';
+  }
+
+  public @Nullable JSONObject attributionToJSONObject() {
+    // Creates a JSON Blob as a string of nested values that we can then process on the server.
+    if (!isAttributionEnabled) {
+      return null;
+    }
+
+    try {
+      JSONObject attribution = new JSONObject();
+      for (int i = 0, size = tagTimeMs.size(); i < size; i++) {
+        long currentTagTimeMs = tagTimeMs.valueAt(i);
+        if (currentTagTimeMs > 0) {
+          attribution.put(tagTimeMs.keyAt(i), currentTagTimeMs);
+        }
+      }
+      return attribution;
+    } catch (JSONException ex) {
+      SystemMetricsLogger.wtf("WakeLockMetrics", "Failed to serialize attribution data", ex);
+    }
+
+    return null;
   }
 }

--- a/reporters/src/main/java/com/facebook/battery/reporter/composite/CompositeMetricsReporter.java
+++ b/reporters/src/main/java/com/facebook/battery/reporter/composite/CompositeMetricsReporter.java
@@ -7,6 +7,7 @@
  */
 package com.facebook.battery.reporter.composite;
 
+import android.support.annotation.Nullable;
 import android.support.v4.util.SimpleArrayMap;
 import com.facebook.battery.metrics.composite.CompositeMetrics;
 import com.facebook.battery.metrics.core.SystemMetrics;
@@ -39,5 +40,11 @@ public class CompositeMetricsReporter implements SystemMetricsReporter<Composite
       Class<T> metricsClass, SystemMetricsReporter<T> reporter) {
     mMetricsReporterMap.put(metricsClass, reporter);
     return this;
+  }
+
+  @Nullable
+  public <S extends SystemMetrics<S>, T extends SystemMetricsReporter<S>> T getReporter(
+      Class<S> metricsClass) {
+    return (T) mMetricsReporterMap.get(metricsClass);
   }
 }


### PR DESCRIPTION
Summary: TSIA: started using the new wakelock collector for primary instrumentation as well, leaving in a kill switch just in case things go wrong.

Differential Revision: D6765187

fbshipit-source-id: 0113ffb76685c3a8bbf05ad09da0462857860774