### PR TITLE
Don't use Log.wtf

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/core/SystemMetricsLogger.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/core/SystemMetricsLogger.java
@@ -41,7 +41,8 @@ public final class SystemMetricsLogger {
     if (sDelegate != null) {
       sDelegate.wtf(tag, message, cause);
     } else {
-      Log.wtf(tag, message, cause);
+      // This is explicitly `Log.e` to avoid possibly crashing the app.
+      Log.e(tag, message, cause);
     }
   }
 }


### PR DESCRIPTION
Summary:
Log.wtf can cause a System.exit, as pointed out by jeffv@google.

There's a period after initialization where the delegate for logging isn't hooked up, so soft errors during period that could cause the app to crash/exit /silently/.

Reviewed By: inazaruk

Differential Revision: D7053582

fbshipit-source-id: 0ddf91c03990d41c9f21c0a8ec8fdc54fe990312