### PR TITLE
Handle healthstats getting reset in between

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/healthstats/HealthStatsMetrics.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/healthstats/HealthStatsMetrics.java
@@ -141,7 +141,7 @@ public class HealthStatsMetrics extends SystemMetrics<HealthStatsMetrics> {
     }
     output.dataType = dataType;
 
-    if (b == null) {
+    if (b == null || compareSnapshotAge(this, b) < 0 /* short circuit if healthstats reset */) {
       output.set(this);
     } else if (!strEquals(b.dataType, dataType)) {
       throw new IllegalArgumentException(
@@ -158,6 +158,13 @@ public class HealthStatsMetrics extends SystemMetrics<HealthStatsMetrics> {
     }
 
     return output;
+  }
+
+  /** Checks the age difference of snapshots, similar to String comparisons. */
+  private static long compareSnapshotAge(HealthStatsMetrics a, HealthStatsMetrics b) {
+    long aRealtimeBatteryMs = a.measurement.get(UidHealthStats.MEASUREMENT_REALTIME_BATTERY_MS, 0L);
+    long bRealtimeBatteryMs = b.measurement.get(UidHealthStats.MEASUREMENT_REALTIME_BATTERY_MS, 0L);
+    return aRealtimeBatteryMs - bRealtimeBatteryMs;
   }
 
   @VisibleForTesting

--- a/metrics/src/test/java/com/facebook/battery/metrics/healthstats/HealthStatsMetricsTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/healthstats/HealthStatsMetricsTest.java
@@ -6,6 +6,7 @@ import static com.facebook.battery.metrics.healthstats.HealthStatsMetrics.OP_DIF
 import static com.facebook.battery.metrics.healthstats.HealthStatsMetrics.OP_SUM;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
+import android.os.health.UidHealthStats;
 import android.support.v4.util.ArrayMap;
 import android.util.SparseArray;
 import org.junit.Test;
@@ -166,6 +167,20 @@ public class HealthStatsMetricsTest {
     value.put("stats", new HealthStatsMetrics(expectedDiff));
     expectedDiff.stats.put(1234, value);
     assertThat(diff).isEqualTo(expectedDiff);
+  }
+
+  @Test
+  public void testDiffWithReset() {
+    HealthStatsMetrics a = createTestMetrics();
+    a.measurement.put(UidHealthStats.MEASUREMENT_REALTIME_BATTERY_MS, 100L);
+
+    HealthStatsMetrics b = createTestMetrics();
+    b.measurement.put(UidHealthStats.MEASUREMENT_REALTIME_BATTERY_MS, 200L);
+
+    HealthStatsMetrics output = a.diff(b, null);
+    HealthStatsMetrics expectedOutput = createTestMetrics();
+    expectedOutput.measurement.put(UidHealthStats.MEASUREMENT_REALTIME_BATTERY_MS, 100L);
+    assertThat(output).isEqualTo(expectedOutput);
   }
 
   private HealthStatsMetrics createTestMetrics() {


### PR DESCRIPTION
Summary:
This is something I'd avoided adding initially because I couldn't reproduce it locally, but I can see events in marauder for employee data with negative healthstats time, etc. which means healthstats data ended up getting reset in between diffs.

Instead of returning a - b in cases where a has data since after b, return only a instead.

Differential Revision: D7415166

fbshipit-source-id: fe35afaa6105e1197b00678b7085f6a03e5e6b8c