### PR TITLE
Use double comparison

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
@@ -76,10 +76,10 @@ public class CpuMetricsCollector extends SystemMetricsCollector<CpuMetrics> {
     }
 
     CpuMetrics lastSnapshot = mLastSnapshot.get();
-    if (snapshot.userTimeS < lastSnapshot.userTimeS
-        || snapshot.systemTimeS < lastSnapshot.systemTimeS
-        || snapshot.childUserTimeS < lastSnapshot.childUserTimeS
-        || snapshot.childSystemTimeS < lastSnapshot.childSystemTimeS) {
+    if (Double.compare(snapshot.userTimeS, lastSnapshot.userTimeS) < 0
+        || Double.compare(snapshot.systemTimeS, lastSnapshot.systemTimeS) < 0
+        || Double.compare(snapshot.childUserTimeS, lastSnapshot.childUserTimeS) < 0
+        || Double.compare(snapshot.childSystemTimeS, lastSnapshot.childSystemTimeS) < 0) {
       SystemMetricsLogger.wtf(
           TAG, "Cpu Time Decreased from " + lastSnapshot.toString() + " to " + snapshot.toString());
       return false;


### PR DESCRIPTION
Summary: I was looking at the (very very few) soft errors logged from the CpuMetricsController, and found only those of the form 1.000000000000009 < 1 because I'm directly comparing Doubles. Use the correct comparison function instead.

Reviewed By: oyvindkinsey

Differential Revision: D7592637

fbshipit-source-id: 1c28ab0d68f5c44ef0710091f3c00b73afefbc4b